### PR TITLE
Fix IRPrinter to print based on symbol dependency

### DIFF
--- a/include/reffine/pass/symanalysis.h
+++ b/include/reffine/pass/symanalysis.h
@@ -14,12 +14,13 @@ class SymAnalysis : public IRPass {
 public:
     explicit SymAnalysis(IRPassCtx& ctx) : IRPass(ctx) {}
 
-    static map<Sym, SymInfo> Build(shared_ptr<Func>);
+    static std::pair<std::map<Sym, SymInfo>, std::vector<Sym>> Build(Func&);
 
 private:
     void Visit(SymNode&) final;
 
     map<Sym, SymInfo> _syminfo_map;
+    std::vector<Sym> _ordered_syms;
 };
 
 }  // namespace reffine

--- a/include/reffine/pass/symanalysis.h
+++ b/include/reffine/pass/symanalysis.h
@@ -14,7 +14,8 @@ class SymAnalysis : public IRPass {
 public:
     explicit SymAnalysis(IRPassCtx& ctx) : IRPass(ctx) {}
 
-    static std::pair<std::map<Sym, SymInfo>, std::vector<Sym>> Build(Func&);
+    static std::pair<std::map<Sym, SymInfo>, std::vector<Sym>> Build(
+        shared_ptr<Func>);
 
 private:
     void Visit(SymNode&) final;

--- a/include/reffine/pass/symanalysis.h
+++ b/include/reffine/pass/symanalysis.h
@@ -8,20 +8,20 @@ namespace reffine {
 
 struct SymInfo {
     int count = 0;
+    int order;
 };
 
 class SymAnalysis : public IRPass {
 public:
     explicit SymAnalysis(IRPassCtx& ctx) : IRPass(ctx) {}
 
-    static std::pair<std::map<Sym, SymInfo>, std::vector<Sym>> Build(
-        shared_ptr<Func>);
+    static map<Sym, SymInfo> Build(shared_ptr<Func>);
 
 private:
     void Visit(SymNode&) final;
 
     map<Sym, SymInfo> _syminfo_map;
-    std::vector<Sym> _ordered_syms;
+    int _cur_order = 0;
 };
 
 }  // namespace reffine

--- a/src/pass/printer.cpp
+++ b/src/pass/printer.cpp
@@ -1,4 +1,5 @@
 #include "reffine/pass/printer.h"
+#include "reffine/pass/symanalysis.h"
 
 #include <unordered_set>
 
@@ -268,6 +269,7 @@ void IRPrinter::Visit(Func& fn)
     for (auto& input : fn.inputs) { ostr << input->name << ", "; }
     ostr << (fn.inputs.size() > 0 ? "\b\b" : "") << ") {";
 
+    auto [syminfo_map, ordered_symbols] = SymAnalysis::Build(fn);
     enter_block();
     for (auto& [sym, val] : fn.tbl) {
         emitassign(sym, val);

--- a/src/pass/symanalysis.cpp
+++ b/src/pass/symanalysis.cpp
@@ -8,16 +8,18 @@ using namespace reffine::reffiner;
 void SymAnalysis::Visit(SymNode& symbol)
 {
     auto tmp = this->tmp_sym(symbol);
+    if (_syminfo_map[tmp].count == 0) { _ordered_syms.push_back(tmp); }
     _syminfo_map[tmp].count++;
 
     IRPass::Visit(symbol);
 }
 
-map<Sym, SymInfo> SymAnalysis::Build(shared_ptr<Func> func)
+std::pair<std::map<Sym, SymInfo>, std::vector<Sym>> SymAnalysis::Build(Func& func)
 {
-    IRPassCtx ctx(func->tbl);
+    IRPassCtx ctx(func.tbl);
     SymAnalysis pass(ctx);
-    func->Accept(pass);
+    func.Accept(pass);
 
-    return pass._syminfo_map;
+    return { pass._syminfo_map, pass._ordered_syms };
+
 }

--- a/src/pass/symanalysis.cpp
+++ b/src/pass/symanalysis.cpp
@@ -16,7 +16,7 @@ void SymAnalysis::Visit(SymNode& symbol)
     _syminfo_map[tmp].count++;
 }
 
-std::map<Sym, SymInfo> SymAnalysis::Build(shared_ptr<Func> func)
+map<Sym, SymInfo> SymAnalysis::Build(shared_ptr<Func> func)
 {
     IRPassCtx ctx(func->tbl);
     SymAnalysis pass(ctx);

--- a/src/pass/symanalysis.cpp
+++ b/src/pass/symanalysis.cpp
@@ -14,12 +14,12 @@ void SymAnalysis::Visit(SymNode& symbol)
     IRPass::Visit(symbol);
 }
 
-std::pair<std::map<Sym, SymInfo>, std::vector<Sym>> SymAnalysis::Build(Func& func)
+std::pair<std::map<Sym, SymInfo>, std::vector<Sym>> SymAnalysis::Build(
+    shared_ptr<Func> func)
 {
-    IRPassCtx ctx(func.tbl);
+    IRPassCtx ctx(func->tbl);
     SymAnalysis pass(ctx);
-    func.Accept(pass);
+    func->Accept(pass);
 
-    return { pass._syminfo_map, pass._ordered_syms };
-
+    return {pass._syminfo_map, pass._ordered_syms};
 }

--- a/src/pass/symanalysis.cpp
+++ b/src/pass/symanalysis.cpp
@@ -8,18 +8,19 @@ using namespace reffine::reffiner;
 void SymAnalysis::Visit(SymNode& symbol)
 {
     auto tmp = this->tmp_sym(symbol);
-    if (_syminfo_map[tmp].count == 0) { _ordered_syms.push_back(tmp); }
-    _syminfo_map[tmp].count++;
 
     IRPass::Visit(symbol);
+    if (_syminfo_map[tmp].count == 0) {
+        _syminfo_map[tmp].order = _cur_order++;
+    }
+    _syminfo_map[tmp].count++;
 }
 
-std::pair<std::map<Sym, SymInfo>, std::vector<Sym>> SymAnalysis::Build(
-    shared_ptr<Func> func)
+std::map<Sym, SymInfo> SymAnalysis::Build(shared_ptr<Func> func)
 {
     IRPassCtx ctx(func->tbl);
     SymAnalysis pass(ctx);
     func->Accept(pass);
 
-    return {pass._syminfo_map, pass._ordered_syms};
+    return pass._syminfo_map;
 }


### PR DESCRIPTION
Issue: Fix IRPrinter to print based on symbol dependency #31 

- Keep track of symbol order and whether it is used in the SymAnalysis pass
- Iterate only through ordered symbols in IRPrinter